### PR TITLE
fix(frontend): Vercel 빌드 오류 수정

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import type { Metadata } from "next";
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import Snackbar from '@mui/material/Snackbar';


### PR DESCRIPTION
- `layout.tsx` 파일에 'use client'를 추가하면서 사용하지 않게 된 'Metadata' 타입을 import 구문에서 제거합니다.
- 이로 인해 발생하던 ESLint의 'no-unused-vars' 오류를 해결하고 Vercel 빌드가 성공하도록 합니다.