### PR TITLE
Fix frontend state mutation and error filtering bugs

### DIFF
--- a/frontend/src/app/components/InfiniteScrollTranslationViewer.tsx
+++ b/frontend/src/app/components/InfiniteScrollTranslationViewer.tsx
@@ -105,19 +105,20 @@ export default function InfiniteScrollTranslationViewer({
   // Merge translated text from loaded segments
   const mergedTranslatedText = React.useMemo(() => {
     if (loadedSegments.length > 0) {
+      const segmentsSortedByIndex = loadedSegments
+        .slice()
+        .sort((a, b) => a.segment_index - b.segment_index);
       // Check if segments have post-edit data (edited_translation field)
-      const firstSegment = loadedSegments[0];
+      const firstSegment = segmentsSortedByIndex[0];
       const hasPostEditData = 'edited_translation' in firstSegment || 'original_translation' in firstSegment;
-      
+
       if (hasPostEditData) {
-        return loadedSegments
-          .sort((a, b) => a.segment_index - b.segment_index)
+        return segmentsSortedByIndex
           .map(segment => segment.edited_translation || segment.original_translation || segment.translated_text)
           .join('\n');
       }
-      
-      return loadedSegments
-        .sort((a, b) => a.segment_index - b.segment_index)
+
+      return segmentsSortedByIndex
         .map(segment => segment.translated_text)
         .join('\n');
     }
@@ -148,6 +149,7 @@ export default function InfiniteScrollTranslationViewer({
     
     if (loadedSegments.length > 0 && loadedSegments[0].source_text !== undefined) {
       return loadedSegments
+        .slice()
         .sort((a, b) => a.segment_index - b.segment_index)
         .map(segment => segment.source_text)
         .join('\n');

--- a/frontend/src/app/hooks/useCanvasState.ts
+++ b/frontend/src/app/hooks/useCanvasState.ts
@@ -224,12 +224,14 @@ export function useCanvasState() {
     }
     if (postEditLog?.segments) {
       return postEditLog.segments
+        .slice()
         .sort((a, b) => a.segment_index - b.segment_index)
         .map(segment => segment.source_text)
         .join('\n');
     }
     if (translationSegments?.segments && translationSegments.segments.length > 0) {
       return translationSegments.segments
+        .slice()
         .sort((a, b) => a.segment_index - b.segment_index)
         .map(segment => segment.source_text)
         .join('\n');


### PR DESCRIPTION
## Summary
- avoid mutating translation segment data when building source text in the canvas state
- keep infinite scroll viewers from reordering cached segments by sorting on a copy before merging text
- honor the active validation error filters when computing navigable error segments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb6faf8404832886187a4f53a1afa2