### PR TITLE
feat(glossary): 용어집 JSON 가져오기/내보내기 기능 추가

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -119,6 +119,18 @@ router.add_api_route(
     methods=["POST"],
     tags=["export"]
 )
+router.add_api_route(
+    "/jobs/{job_id}/glossary",
+    export_routes.download_glossary,
+    methods=["GET"],
+    tags=["jobs"]
+)
+router.add_api_route(
+    "/jobs/{job_id}/glossary",
+    export_routes.upload_glossary,
+    methods=["POST"],
+    tags=["jobs"]
+)
 
 # Analysis endpoints
 router.add_api_route(

--- a/frontend/src/app/components/StyleConfiguration/GlossaryEditor.tsx
+++ b/frontend/src/app/components/StyleConfiguration/GlossaryEditor.tsx
@@ -20,6 +20,7 @@ import {
 import {
   Add as AddIcon,
   Delete as DeleteIcon,
+  Upload as UploadIcon,
 } from '@mui/icons-material';
 import { GlossaryTerm } from '../../types/ui';
 
@@ -36,6 +37,98 @@ export default function GlossaryEditor({
   glossaryAnalysisError,
   onGlossaryChange,
 }: GlossaryEditorProps) {
+  const parseImportedGlossary = (json: any): GlossaryTerm[] => {
+    try {
+      if (!json) return [];
+      // Structured response shape
+      if (Array.isArray((json as any).glossary)) {
+        return (json as any).glossary
+          .map((it: any) => ({ source: String(it.term || ''), korean: String(it.translation || '') }))
+          .filter((t: GlossaryTerm) => t.source && t.korean);
+      }
+      if ((json as any).translated_terms && Array.isArray((json as any).translated_terms.translations)) {
+        return (json as any).translated_terms.translations
+          .map((it: any) => ({ source: String(it.source || ''), korean: String(it.korean || '') }))
+          .filter((t: GlossaryTerm) => t.source && t.korean);
+      }
+      // Plain dict
+      if (typeof json === 'object' && !Array.isArray(json)) {
+        return Object.entries(json as Record<string, unknown>)
+          .map(([k, v]) => ({ source: String(k), korean: String(v as any) }))
+          .filter((t: GlossaryTerm) => t.source && t.korean);
+      }
+      // Array forms
+      if (Array.isArray(json)) {
+        const out: GlossaryTerm[] = [];
+        for (const item of json) {
+          if (typeof item !== 'object' || item == null) continue;
+          if ('source' in item && 'korean' in item) {
+            const source = String((item as any).source || '');
+            const korean = String((item as any).korean || '');
+            if (source && korean) out.push({ source, korean });
+            continue;
+          }
+          if ('term' in item && 'translation' in item) {
+            const source = String((item as any).term || '');
+            const korean = String((item as any).translation || '');
+            if (source && korean) out.push({ source, korean });
+            continue;
+          }
+          // Single-key object { "Term": "번역" }
+          const entries = Object.entries(item);
+          if (entries.length === 1) {
+            const [k, v] = entries[0];
+            const source = String(k || '');
+            const korean = String((v as any) || '');
+            if (source && korean) out.push({ source, korean });
+          }
+        }
+        return out;
+      }
+    } catch (e) {
+      // fallthrough
+    }
+    return [];
+  };
+
+  const handleImportGlossaryJson = async () => {
+    try {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = '.json,application/json';
+      input.onchange = async () => {
+        if (!input.files || input.files.length === 0) return;
+        const file = input.files[0];
+        const text = await file.text();
+        let json: any;
+        try {
+          json = JSON.parse(text);
+        } catch (e) {
+          alert('유효한 JSON 파일이 아닙니다.');
+          return;
+        }
+        const imported = parseImportedGlossary(json);
+        if (!imported.length) {
+          alert('인식 가능한 용어집 형식이 아닙니다.');
+          return;
+        }
+        // Merge by source, prefer imported values
+        const mergedMap = new Map<string, string>();
+        for (const term of glossaryData) {
+          if (term.source && term.korean) mergedMap.set(term.source, term.korean);
+        }
+        for (const term of imported) {
+          mergedMap.set(term.source, term.korean);
+        }
+        const merged: GlossaryTerm[] = Array.from(mergedMap.entries()).map(([source, korean]) => ({ source, korean }));
+        onGlossaryChange(merged);
+      };
+      input.click();
+    } catch (error) {
+      console.error('Glossary JSON import error:', error);
+    }
+  };
+
   const handleGlossaryChange = (index: number, field: keyof GlossaryTerm, value: string) => {
     const updated = [...glossaryData];
     updated[index] = { ...updated[index], [field]: value };
@@ -111,9 +204,14 @@ export default function GlossaryEditor({
         </TableContainer>
       ) : null}
 
-      <Button onClick={handleAddGlossaryTerm} startIcon={<AddIcon />} sx={{ mb: 3 }}>
-        용어 추가
-      </Button>
+      <Box sx={{ display: 'flex', gap: 1, mb: 3 }}>
+        <Button onClick={handleAddGlossaryTerm} startIcon={<AddIcon />}>
+          용어 추가
+        </Button>
+        <Button variant="outlined" onClick={handleImportGlossaryJson} startIcon={<UploadIcon />}>
+          JSON 용어집 주입
+        </Button>
+      </Box>
     </Box>
   );
 }

--- a/frontend/src/app/components/canvas/JobSidebar.tsx
+++ b/frontend/src/app/components/canvas/JobSidebar.tsx
@@ -39,6 +39,7 @@ import {
   PictureAsPdf as PdfIcon,
   PlayArrow as PlayArrowIcon,
   AutoStories as AutoStoriesIcon,
+  MenuBook as MenuBookIcon,
 } from '@mui/icons-material';
 import { Job } from '../../types/ui';
 import JobRowActions from './JobRowActions';
@@ -284,6 +285,38 @@ export default function JobSidebar({
                               }}
                             >
                               <DownloadIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title="용어집 다운로드">
+                            <IconButton
+                              size="small"
+                              onClick={async (e) => {
+                                e.stopPropagation();
+                                const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+                                try {
+                                  const token = await getCachedClerkToken(getToken);
+                                  const response = await fetch(`${API_URL}/api/v1/jobs/${job.id}/glossary?structured=true`, {
+                                    headers: {
+                                      'Authorization': token ? `Bearer ${token}` : '',
+                                    },
+                                  });
+                                  if (!response.ok) throw new Error('Glossary download failed');
+                                  const blob = await response.blob();
+                                  const url = window.URL.createObjectURL(blob);
+                                  const a = document.createElement('a');
+                                  a.href = url;
+                                  const baseFilename = job.filename ? job.filename.replace(/\.[^/.]+$/, '') : `job_${job.id}`;
+                                  a.download = `${baseFilename}_glossary.json`;
+                                  document.body.appendChild(a);
+                                  a.click();
+                                  document.body.removeChild(a);
+                                  window.URL.revokeObjectURL(url);
+                                } catch (error) {
+                                  console.error('Glossary download error:', error);
+                                }
+                              }}
+                            >
+                              <MenuBookIcon fontSize="small" />
                             </IconButton>
                           </Tooltip>
                           {job.status === 'FAILED' && (

--- a/frontend/src/app/components/jobs/JobRow.tsx
+++ b/frontend/src/app/components/jobs/JobRow.tsx
@@ -51,7 +51,7 @@ export default function JobRow({
 
   const handleDownloadGlossary = () => {
     const filename = `${job.filename.split('.')[0]}_glossary.json`;
-    onDownload(`${apiUrl}/api/v1/jobs/${job.id}/glossary`, filename);
+    onDownload(`${apiUrl}/api/v1/jobs/${job.id}/glossary?structured=true`, filename);
   };
 
   const handleDownloadPromptLogs = () => {
@@ -100,6 +100,7 @@ export default function JobRow({
           onDownloadContextLogs={handleDownloadContextLogs}
           onDownloadValidationReport={() => onDownloadValidationReport(job.id)}
           onDownloadPostEditLog={() => onDownloadPostEditLog(job.id)}
+          apiUrl={apiUrl}
           onOpenSidebar={() => onOpenSidebar(job)}
           onTriggerValidation={() => onTriggerValidation(job.id)}
           onTriggerPostEdit={() => onTriggerPostEdit(job.id)}

--- a/frontend/src/app/components/jobs/components/DownloadActions.tsx
+++ b/frontend/src/app/components/jobs/components/DownloadActions.tsx
@@ -15,6 +15,8 @@ import {
   PictureAsPdf as PdfIcon,
 } from '@mui/icons-material';
 import { Job } from '../../../types/ui';
+import { useAuth } from '@clerk/nextjs';
+import { getCachedClerkToken } from '../../../utils/authToken';
 
 interface DownloadActionsProps {
   job: Job;
@@ -30,6 +32,7 @@ interface DownloadActionsProps {
   onTriggerPostEdit: () => void;
   onDelete: () => void;
   devMode?: boolean;
+  apiUrl: string;
 }
 
 export default function DownloadActions({
@@ -46,7 +49,9 @@ export default function DownloadActions({
   onTriggerPostEdit,
   onDelete,
   devMode = false,
+  apiUrl,
 }: DownloadActionsProps) {
+  const { getToken } = useAuth();
   return (
     <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}>
       {(job.status === 'COMPLETED' || job.status === 'FAILED') && (

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -343,6 +343,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/jobs/{job_id}/glossary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download Glossary
+         * @description Download glossary for a translation job.
+         *     If structured=true, returns structured glossary JSON payload.
+         *     Otherwise returns raw dictionary JSON.
+         */
+        get: operations["download_glossary_api_v1_jobs__job_id__glossary_get"];
+        put?: never;
+        /**
+         * Upload Glossary
+         * @description Upload and apply glossary to a job (merge or replace).
+         *     Accepts flexible formats: dict, array of {source,korean}, array of {term,translation}, etc.
+         */
+        post: operations["upload_glossary_api_v1_jobs__job_id__glossary_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/analysis/style": {
         parameters: {
             query?: never;
@@ -1421,29 +1448,6 @@ export interface components {
             /** Profile Json */
             profile_json?: string | null;
         };
-        /** Body_resume_job_api_v1_jobs__job_id__resume_post */
-        Body_resume_job_api_v1_jobs__job_id__resume_post: {
-            /** Api Key */
-            api_key: string;
-            /**
-             * Model Name
-             * @default gemini-2.5-flash-lite
-             */
-            model_name: string;
-            /** Translation Model Name */
-            translation_model_name?: string | null;
-            /** Style Model Name */
-            style_model_name?: string | null;
-            /** Glossary Model Name */
-            glossary_model_name?: string | null;
-            /**
-             * Api Provider
-             * @default gemini
-             */
-            api_provider: string;
-            /** Provider Config */
-            provider_config?: string | null;
-        };
         /** Body_upload_image_api_v1_community_images_post */
         Body_upload_image_api_v1_community_images_post: {
             /**
@@ -1867,6 +1871,32 @@ export interface components {
             is_pinned?: boolean | null;
             /** Images */
             images?: string[] | null;
+        };
+        /**
+         * ResumeRequest
+         * @description Request payload for resuming a failed translation job.
+         */
+        ResumeRequest: {
+            /** Api Key */
+            api_key?: string | null;
+            /**
+             * Model Name
+             * @default gemini-2.5-flash-lite
+             */
+            model_name: string | null;
+            /** Translation Model Name */
+            translation_model_name?: string | null;
+            /** Style Model Name */
+            style_model_name?: string | null;
+            /** Glossary Model Name */
+            glossary_model_name?: string | null;
+            /**
+             * Api Provider
+             * @default gemini
+             */
+            api_provider: string | null;
+            /** Provider Config */
+            provider_config?: string | null;
         };
         /**
          * StyleAnalysisResponse
@@ -2395,7 +2425,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/x-www-form-urlencoded": components["schemas"]["Body_resume_job_api_v1_jobs__job_id__resume_post"];
+                "application/json": components["schemas"]["ResumeRequest"];
             };
         };
         responses: {
@@ -2599,6 +2629,79 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    download_glossary_api_v1_jobs__job_id__glossary_get: {
+        parameters: {
+            query?: {
+                structured?: boolean;
+            };
+            header?: never;
+            path: {
+                job_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    upload_glossary_api_v1_jobs__job_id__glossary_post: {
+        parameters: {
+            query?: {
+                mode?: string;
+                structured?: boolean;
+            };
+            header?: never;
+            path: {
+                job_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/openapi.json
+++ b/openapi.json
@@ -319,9 +319,9 @@
         "requestBody": {
           "required": true,
           "content": {
-            "application/x-www-form-urlencoded": {
+            "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Body_resume_job_api_v1_jobs__job_id__resume_post"
+                "$ref": "#/components/schemas/ResumeRequest"
               }
             }
           }
@@ -644,6 +644,128 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/{job_id}/glossary": {
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Download Glossary",
+        "description": "Download glossary for a translation job.\nIf structured=true, returns structured glossary JSON payload.\nOtherwise returns raw dictionary JSON.",
+        "operationId": "download_glossary_api_v1_jobs__job_id__glossary_get",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Job Id"
+            }
+          },
+          {
+            "name": "structured",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Structured"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Upload Glossary",
+        "description": "Upload and apply glossary to a job (merge or replace).\nAccepts flexible formats: dict, array of {source,korean}, array of {term,translation}, etc.",
+        "operationId": "upload_glossary_api_v1_jobs__job_id__glossary_post",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Job Id"
+            }
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "merge",
+              "title": "Mode"
+            }
+          },
+          {
+            "name": "structured",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Structured"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Glossary"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -3214,73 +3336,6 @@
         ],
         "title": "Body_generate_character_bases_api_v1_illustrations__job_id__character_base_generate_post"
       },
-      "Body_resume_job_api_v1_jobs__job_id__resume_post": {
-        "properties": {
-          "api_key": {
-            "type": "string",
-            "title": "Api Key"
-          },
-          "model_name": {
-            "type": "string",
-            "title": "Model Name",
-            "default": "gemini-2.5-flash-lite"
-          },
-          "translation_model_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Translation Model Name"
-          },
-          "style_model_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Style Model Name"
-          },
-          "glossary_model_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Glossary Model Name"
-          },
-          "api_provider": {
-            "type": "string",
-            "title": "Api Provider",
-            "default": "gemini"
-          },
-          "provider_config": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Provider Config"
-          }
-        },
-        "type": "object",
-        "required": [
-          "api_key"
-        ],
-        "title": "Body_resume_job_api_v1_jobs__job_id__resume_post"
-      },
       "Body_upload_image_api_v1_community_images_post": {
         "properties": {
           "file": {
@@ -4240,6 +4295,92 @@
         },
         "type": "object",
         "title": "PostUpdate"
+      },
+      "ResumeRequest": {
+        "properties": {
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key"
+          },
+          "model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Name",
+            "default": "gemini-2.5-flash-lite"
+          },
+          "translation_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Translation Model Name"
+          },
+          "style_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Style Model Name"
+          },
+          "glossary_model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Glossary Model Name"
+          },
+          "api_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Provider",
+            "default": "gemini"
+          },
+          "provider_config": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Config"
+          }
+        },
+        "type": "object",
+        "title": "ResumeRequest",
+        "description": "Request payload for resuming a failed translation job."
       },
       "StyleAnalysisResponse": {
         "properties": {


### PR DESCRIPTION
사용자가 번역 작업의 용어집을 JSON 파일로 가져오고 내보낼 수 있는 기능을 추가합니다. 이를 통해 사용자는 용어 목록을 오프라인에서 편집하고, 다른 작업과 공유하며, 재사용할 수 있게 되어 작업 효율성이 향상됩니다.

주요 변경 사항:
- **Backend**:
  - 작업 용어집을 다운로드하기 위한 `GET /api/v1/jobs/{job_id}/glossary` 엔드포인트를 추가했습니다.
  - 'merge' 및 'replace' 모드를 지원하는 새 용어집을 업로드하기 위한 `POST /api/v1/jobs/{job_id}/glossary` 엔드포인트를 추가했습니다.
  - 서비스 계층에서 다양한 형식의 JSON 용어집 파일을 유연하게 파싱할 수 있도록 구현했습니다.

- **Frontend**:
  - 작업 메뉴에 "용어집 다운로드" 버튼을 추가했습니다.
  - 용어집 편집기에 "JSON 용어집 주입" 버튼을 추가하여, 사용자가 파일을 업로드하고 그 내용을 현재 용어집과 병합할 수 있도록 했습니다.

- **API**:
  - 새로운 엔드포인트를 반영하여 `openapi.json`을 업데이트하고 `frontend/src/types/api.d.ts`를 다시 생성했습니다.