### PR TITLE
feat: 삽화 생성 토큰 사용량 추적 기능 추가

### DIFF
--- a/backend/celery_tasks/illustrations.py
+++ b/backend/celery_tasks/illustrations.py
@@ -143,6 +143,7 @@ def generate_illustrations_task(
                 enable_caching=config.cache_enabled,
                 model_name=model_name,
                 client=client,
+                output_dir=settings.job_storage_base,
             )
             print(f"[ILLUSTRATIONS TASK] Generator initialized successfully with model: {settings.illustration_model}")
         except Exception as e:
@@ -186,7 +187,7 @@ def generate_illustrations_task(
             dyn_builder = None
 
         # Load segments from log files instead of database for richer metadata
-        log_dir = Path(f"logs/jobs/{job_id}/segments/translation")
+        log_dir = Path(settings.job_storage_base) / str(job_id) / "segments" / "translation"
         segments = []
 
         if log_dir.exists():

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -31,6 +31,8 @@ class Settings(BaseSettings):
     storage_backend: str = "local"  # local, s3, gcs
     upload_directory: str = Field(default="uploads", env="UPLOAD_DIR")
     job_storage_base: str = Field(default="logs/jobs", env="JOB_STORAGE_BASE")
+    # Legacy plain-text output directory (kept for backward compatibility)
+    legacy_translated_dir: str = Field(default="translated_novel", env="LEGACY_TRANSLATED_DIR")
     max_file_size: int = 100_000_000  # 100MB
     allowed_extensions: List[str] = Field(
         default_factory=lambda: [
@@ -138,6 +140,15 @@ class Settings(BaseSettings):
     @field_validator("job_storage_base")
     @classmethod
     def ensure_job_storage_dir(cls, v):
+        path = Path(v)
+        if not path.is_absolute():
+            path = Path(os.getcwd()) / path
+        path.mkdir(parents=True, exist_ok=True)
+        return str(path)
+
+    @field_validator("legacy_translated_dir")
+    @classmethod
+    def ensure_legacy_translated_dir(cls, v):
         path = Path(v)
         if not path.is_absolute():
             path = Path(os.getcwd()) / path

--- a/backend/domains/translation/models.py
+++ b/backend/domains/translation/models.py
@@ -68,4 +68,5 @@ class TranslationUsageLog(Base):
     prompt_tokens = Column(Integer, nullable=True, default=0)
     completion_tokens = Column(Integer, nullable=True, default=0)
     total_tokens = Column(Integer, nullable=True, default=0)
+    usage_category = Column(String, nullable=False, default="translation", index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/domains/translation/service.py
+++ b/backend/domains/translation/service.py
@@ -957,7 +957,9 @@ class TranslationDomainService(DomainServiceBase):
                 import json
                 from pathlib import Path
                 
-                segments_path = Path(f"logs/jobs/{job_id}/output/segments.json")
+                from backend.config.settings import get_settings
+                base_dir = Path(get_settings().job_storage_base)
+                segments_path = base_dir / str(job_id) / "output" / "segments.json"
                 if segments_path.exists():
                     try:
                         with open(segments_path, 'r', encoding='utf-8') as f:
@@ -1019,7 +1021,9 @@ class TranslationDomainService(DomainServiceBase):
                 import json
                 from pathlib import Path
                 
-                segments_path = Path(f"logs/jobs/{job_id}/output/segments.json")
+                from backend.config.settings import get_settings
+                base_dir = Path(get_settings().job_storage_base)
+                segments_path = base_dir / str(job_id) / "output" / "segments.json"
                 if segments_path.exists():
                     try:
                         with open(segments_path, 'r', encoding='utf-8') as f:

--- a/backend/domains/translation/storage_utils.py
+++ b/backend/domains/translation/storage_utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import logging
 
 from backend.domains.shared.storage import Storage
+from backend.config.settings import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -50,8 +51,9 @@ class TranslationStorageManager:
         # Determine base filename
         base_name = Path(original_filename).stem
         
-        # Save directly to logs/jobs directory (outside of storage abstraction)
-        logs_output_dir = Path(f"logs/jobs/{job_id}/output")
+        # Save directly to job storage base directory (outside of storage abstraction)
+        base_dir = Path(get_settings().job_storage_base)
+        logs_output_dir = base_dir / str(job_id) / "output"
         logs_output_dir.mkdir(parents=True, exist_ok=True)
         logs_output_path = logs_output_dir / "translated.txt"
         
@@ -66,7 +68,7 @@ class TranslationStorageManager:
         
         # Save to legacy directory if requested
         if save_to_legacy:
-            legacy_dir = Path("translated_novel")
+            legacy_dir = Path(get_settings().legacy_translated_dir)
             legacy_dir.mkdir(parents=True, exist_ok=True)
             legacy_path = legacy_dir / f"{job_id}_{base_name}_translated.txt"
             try:
@@ -96,8 +98,9 @@ class TranslationStorageManager:
         """
         import json
         
-        # Save directly to logs/jobs directory
-        segments_dir = Path(f"logs/jobs/{job_id}/output")
+        # Save directly to job storage base directory
+        base_dir = Path(get_settings().job_storage_base)
+        segments_dir = base_dir / str(job_id) / "output"
         segments_dir.mkdir(parents=True, exist_ok=True)
         segments_path = segments_dir / "segments.json"
         
@@ -127,7 +130,8 @@ class TranslationStorageManager:
             Translation content as string, or None if not found
         """
         # Try job-specific directory first
-        job_path = Path(f"logs/jobs/{job_id}/output/translated.txt")
+        base_dir = Path(get_settings().job_storage_base)
+        job_path = base_dir / str(job_id) / "output" / "translated.txt"
         
         try:
             if job_path.exists():
@@ -139,7 +143,8 @@ class TranslationStorageManager:
         # Try legacy directory as fallback
         if original_filename:
             base_name = Path(original_filename).stem
-            legacy_path = Path(f"translated_novel/{job_id}_{base_name}_translated.txt")
+            legacy_dir = Path(get_settings().legacy_translated_dir)
+            legacy_path = legacy_dir / f"{job_id}_{base_name}_translated.txt"
             try:
                 if legacy_path.exists():
                     with open(legacy_path, 'r', encoding='utf-8') as f:
@@ -153,7 +158,8 @@ class TranslationStorageManager:
         """Read partial translated segments stored for resume support."""
         import json
 
-        cache_path = Path(f"logs/jobs/{job_id}/output/partial_segments.json")
+        base_dir = Path(get_settings().job_storage_base)
+        cache_path = base_dir / str(job_id) / "output" / "partial_segments.json"
         if not cache_path.exists():
             return None
 

--- a/backend/domains/user/schemas.py
+++ b/backend/domains/user/schemas.py
@@ -57,9 +57,14 @@ class ModelTokenUsage(TokenUsageTotals):
     model: str
 
 
+class IllustrationUsageTotals(TokenUsageTotals):
+    image_count: int
+
+
 class TokenUsageDashboard(BaseModel):
     total: TokenUsageTotals
     per_model: List[ModelTokenUsage]
+    illustrations: IllustrationUsageTotals
     last_updated: Optional[datetime.datetime] = None
 
 # --- Announcement Schemas ---

--- a/backend/migrations/versions/d45c9e8f3b10_add_usage_category_to_usage_logs.py
+++ b/backend/migrations/versions/d45c9e8f3b10_add_usage_category_to_usage_logs.py
@@ -1,0 +1,77 @@
+"""Add usage_category to translation usage logs
+
+Revision ID: d45c9e8f3b10
+Revises: b2e468b624fb
+Create Date: 2025-09-10 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d45c9e8f3b10"
+down_revision: Union[str, Sequence[str], None] = ("1b2d3f4a1c7b", "c3a7c1b2d4e5")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema by adding usage_category column."""
+    bind = op.get_bind()
+    is_sqlite = bind.dialect.name == "sqlite"
+
+    if is_sqlite:
+        existing_columns = {
+            row[1] for row in bind.execute(sa.text("PRAGMA table_info('translation_usage_logs')"))
+        }
+        if "usage_category" not in existing_columns:
+            op.execute(
+                sa.text(
+                    "ALTER TABLE translation_usage_logs ADD COLUMN usage_category VARCHAR DEFAULT 'translation'"
+                )
+            )
+    else:
+        with op.batch_alter_table("translation_usage_logs") as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "usage_category",
+                    sa.String(),
+                    nullable=False,
+                    server_default="translation",
+                )
+            )
+        op.execute(
+            sa.text(
+                "UPDATE translation_usage_logs SET usage_category = 'translation' WHERE usage_category IS NULL"
+            )
+        )
+        with op.batch_alter_table("translation_usage_logs") as batch_op:
+            batch_op.alter_column("usage_category", server_default=None)
+
+    op.create_index(
+        "ix_translation_usage_logs_usage_category",
+        "translation_usage_logs",
+        ["usage_category"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema by dropping usage_category column."""
+    op.drop_index(
+        "ix_translation_usage_logs_usage_category",
+        table_name="translation_usage_logs",
+    )
+
+    bind = op.get_bind()
+    is_sqlite = bind.dialect.name == "sqlite"
+
+    if is_sqlite:
+        # SQLite cannot drop columns without complex workarounds; skip.
+        return
+
+    with op.batch_alter_table("translation_usage_logs") as batch_op:
+        batch_op.drop_column("usage_category")

--- a/backend/services/aws_task_output_service.py
+++ b/backend/services/aws_task_output_service.py
@@ -100,8 +100,9 @@ class AWSTaskOutputService:
         }
 
         try:
-            # Get the job output directory
-            job_dir = Path(f"logs/jobs/{job_id}")
+            # Get the job output directory from configured job storage base
+            base_dir = Path(get_settings().job_storage_base)
+            job_dir = base_dir / str(job_id)
 
             if not job_dir.exists():
                 logger.debug(f"No output directory found for job {job_id}")

--- a/core/translation/progress_tracker.py
+++ b/core/translation/progress_tracker.py
@@ -214,6 +214,7 @@ class ProgressTracker:
                     prompt_tokens=normalized.prompt_tokens,
                     completion_tokens=normalized.completion_tokens,
                     total_tokens=normalized.total_tokens,
+                    usage_category="translation",
                 )
             )
 

--- a/frontend/src/app/usage/page.tsx
+++ b/frontend/src/app/usage/page.tsx
@@ -118,10 +118,13 @@ export default function TokenUsagePage() {
   const hasUsage = useMemo(() => {
     if (!data) return false;
     const totals = data.total;
+    const illustrations = data.illustrations;
     return (
       (totals?.total_tokens ?? 0) > 0 ||
       (totals?.input_tokens ?? 0) > 0 ||
       (totals?.output_tokens ?? 0) > 0 ||
+      (illustrations?.total_tokens ?? 0) > 0 ||
+      (illustrations?.image_count ?? 0) > 0 ||
       (data.per_model?.length ?? 0) > 0
     );
   }, [data]);
@@ -201,7 +204,7 @@ export default function TokenUsagePage() {
               토큰 사용량
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              모델별 입력/출력 토큰 사용량을 확인하세요.
+              모델별 입력/출력 토큰 사용량과 삽화 생성 내역을 확인하세요.
             </Typography>
           </Box>
           <Stack direction="row" spacing={1} justifyContent="flex-end">
@@ -246,11 +249,30 @@ export default function TokenUsagePage() {
                     )}
                   </Stack>
                   {data ? (
-                    <Box display="grid" gridTemplateColumns={{ xs: '1fr', sm: 'repeat(3, 1fr)' }} gap={2}>
-                      <UsageMetricCard label="입력 토큰" value={data.total.input_tokens} />
-                      <UsageMetricCard label="출력 토큰" value={data.total.output_tokens} />
-                      <UsageMetricCard label="총 토큰" value={data.total.total_tokens} highlight />
-                    </Box>
+                    <Stack spacing={3}>
+                      <Box display="grid" gridTemplateColumns={{ xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)' }} gap={2}>
+                        <UsageMetricCard label="입력 토큰" value={data.total.input_tokens} />
+                        <UsageMetricCard label="출력 토큰" value={data.total.output_tokens} />
+                        <UsageMetricCard label="총 토큰" value={data.total.total_tokens} highlight />
+                      </Box>
+                      {data.illustrations && (
+                        <Stack spacing={1.5}>
+                          <Typography variant="subtitle2" color="text.secondary">
+                            삽화 관련 사용량
+                          </Typography>
+                          <Box
+                            display="grid"
+                            gridTemplateColumns={{ xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' }}
+                            gap={2}
+                          >
+                            <UsageMetricCard label="삽화 입력 토큰" value={data.illustrations.input_tokens} />
+                            <UsageMetricCard label="삽화 출력 토큰" value={data.illustrations.output_tokens} />
+                            <UsageMetricCard label="삽화 총 토큰" value={data.illustrations.total_tokens} />
+                            <UsageMetricCard label="생성된 이미지" value={data.illustrations.image_count} />
+                          </Box>
+                        </Stack>
+                      )}
+                    </Stack>
                   ) : (
                     <Typography variant="body2" color="text.secondary">
                       아직 사용량 데이터가 없습니다.

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -2097,6 +2097,8 @@ export interface components {
             total: components["schemas"]["TokenUsageTotals"];
             /** Per Model */
             per_model: components["schemas"]["ModelTokenUsage"][];
+            /** Illustration Usage */
+            illustrations: components["schemas"]["IllustrationUsageTotals"];
             /** Last Updated */
             last_updated?: string | null;
         };
@@ -2108,6 +2110,17 @@ export interface components {
             output_tokens: number;
             /** Total Tokens */
             total_tokens: number;
+        };
+        /** IllustrationUsageTotals */
+        IllustrationUsageTotals: {
+            /** Input Tokens */
+            input_tokens: number;
+            /** Output Tokens */
+            output_tokens: number;
+            /** Total Tokens */
+            total_tokens: number;
+            /** Image Count */
+            image_count: number;
         };
         /**
          * TranslatedTerm

--- a/openapi.json
+++ b/openapi.json
@@ -4946,6 +4946,10 @@
             "type": "array",
             "title": "Per Model"
           },
+          "illustrations": {
+            "$ref": "#/components/schemas/IllustrationUsageTotals",
+            "title": "Illustration Usage"
+          },
           "last_updated": {
             "anyOf": [
               {
@@ -4962,9 +4966,38 @@
         "type": "object",
         "required": [
           "total",
-          "per_model"
+          "per_model",
+          "illustrations"
         ],
         "title": "TokenUsageDashboard"
+      },
+      "IllustrationUsageTotals": {
+        "properties": {
+          "input_tokens": {
+            "type": "integer",
+            "title": "Input Tokens"
+          },
+          "output_tokens": {
+            "type": "integer",
+            "title": "Output Tokens"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "title": "Total Tokens"
+          },
+          "image_count": {
+            "type": "integer",
+            "title": "Image Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "input_tokens",
+          "output_tokens",
+          "total_tokens",
+          "image_count"
+        ],
+        "title": "IllustrationUsageTotals"
       },
       "TokenUsageTotals": {
         "properties": {

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -189,3 +189,49 @@ def test_user_service_token_usage_dashboard(session: Session) -> None:
     per_model = {entry['model']: entry for entry in summary['per_model']}
     assert per_model['gemini-pro']['total_tokens'] == 100
     assert per_model['openrouter/claude']['input_tokens'] == 30
+    assert summary['illustrations']['total_tokens'] == 0
+    assert summary['illustrations']['image_count'] == 0
+
+
+def test_user_service_includes_illustration_usage(session: Session) -> None:
+    user = create_user(session, index=4)
+    job = create_job(session, owner=user, filename="illustrations.txt")
+
+    log_entries = [
+        TranslationUsageLog(
+            job_id=job.id,
+            user_id=user.id,
+            original_length=0,
+            translated_length=0,
+            translation_duration_seconds=5,
+            model_used="gemini-illustration",
+            prompt_tokens=10,
+            completion_tokens=2,
+            total_tokens=12,
+            usage_category='illustration',
+        ),
+        TranslationUsageLog(
+            job_id=job.id,
+            user_id=user.id,
+            original_length=0,
+            translated_length=0,
+            translation_duration_seconds=3,
+            model_used="gemini-illustration",
+            prompt_tokens=4,
+            completion_tokens=1,
+            total_tokens=5,
+            usage_category='illustration',
+        ),
+    ]
+
+    session.add_all(log_entries)
+    job.illustrations_count = 3
+    session.commit()
+
+    service = UserService(session)
+    summary = service.get_token_usage_dashboard(user.id)
+
+    assert summary['illustrations']['input_tokens'] == 14
+    assert summary['illustrations']['output_tokens'] == 3
+    assert summary['illustrations']['total_tokens'] == 17
+    assert summary['illustrations']['image_count'] == 3


### PR DESCRIPTION
#### 📝 요약 (Summary)

삽화 생성 기능에 대한 토큰 사용량을 별도로 추적하고, 이를 사용자 대시보드에 명확하게 표시하는 기능을 추가합니다. 이를 통해 사용자는 번역과 삽화 생성 비용을 분리하여 확인할 수 있게 되어 투명성이 향상됩니다.

#### 🛠️ 주요 변경 사항 (Key Changes)

*   **백엔드:**
    *   `TranslationUsageLog` 모델에 `usage_category` 필드를 추가하여 'translation'과 'illustration' 사용량을 구분합니다.
    *   삽화 생성 Celery 작업에 토큰 사용량을 측정하는 로직을 구현했습니다.
    *   사용자 토큰 사용량 API가 삽화 관련 데이터(토큰, 이미지 수)를 포함하여 반환하도록 수정했습니다.
    *   데이터베이스 마이그레이션 스크립트를 추가했습니다.
*   **프론트엔드:**
    *   사용량 대시보드 페이지에 '삽화 관련 사용량' 섹션을 추가하여 관련 토큰 및 생성된 이미지 수를 표시합니다.
*   **API:**
    *   OpenAPI 명세를 업데이트하여 API 응답 스키마 변경 사항을 반영했습니다.
*   **테스트:**
    *   삽화 사용량이 정확하게 집계되는지 확인하는 단위 테스트를 추가했습니다.