### PR TITLE
feat: 일러스트 뷰어 성능 및 인증 로직 개선

### DIFF
--- a/backend/domains/illustrations/routes.py
+++ b/backend/domains/illustrations/routes.py
@@ -586,7 +586,6 @@ async def get_illustration_prompt(
         TranslationJob.id == job_id,
         TranslationJob.owner_id == current_user.id
     ).first()
-
     if not job:
         raise HTTPException(status_code=404, detail="Translation job not found")
 

--- a/frontend/src/app/utils/api.ts
+++ b/frontend/src/app/utils/api.ts
@@ -206,12 +206,15 @@ export async function fetchJobTasks(jobId: number, token?: string): Promise<comp
 
 export async function fetchIllustrationStatus(jobId: string, token?: string): Promise<IllustrationStatus | null> {
   try {
-    const response = await fetchWithRetry(`${API_BASE_URL}/api/v1/illustrations/${jobId}/status`, {
-      headers: buildAuthHeaders(token),
-    }, { retries: 3, timeoutMs: 10000 });
+    const headers = token ? buildAuthHeaders(token) : undefined;
+    const response = await fetchWithRetry(
+      `${API_BASE_URL}/api/v1/illustrations/${jobId}/status`,
+      headers ? { headers } : undefined,
+      { retries: 1, timeoutMs: 8000 }
+    );
 
     if (!response.ok) {
-      if (response.status === 404) {
+      if (response.status === 404 || response.status === 401) {
         return null;
       }
       throw new Error(`Failed to fetch illustration status: ${response.statusText}`);


### PR DESCRIPTION
일러스트 뷰어의 사용자 경험과 성능을 향상시키기 위해 데이터 로딩, 캐싱, 인증 처리 방식을 개선했습니다.

주요 변경 사항:
- **콘텐츠 서명 기반 캐싱**: 기존의 타임스탬프 대신 콘텐츠 해시 기반의 서명을 사용하여 데이터 변경을 감지합니다. 이를 통해 더 정확하고 안정적인 클라이언트 사이드 캐시 관리가 가능해졌습니다.
- **인라인 데이터 처리**: API 응답에 포함된 base64 이미지 데이터를 직접 렌더링하고 IndexedDB에 저장하여, 불필요한 개별 이미지 요청을 제거하고 로딩 속도를 개선했습니다.
- **자동 토큰 갱신**: API 요청이 401 (Unauthorized) 에러로 실패할 경우, 자동으로 인증 토큰을 갱신하고 재시도하는 로직을 추가하여 세션 만료로 인한 불편을 최소화했습니다.
- **선택적 인증 지원**: 일러스트 조회 API 호출 시 인증 헤더를 선택적으로 포함하도록 변경하여, 향후 공개/비공개 콘텐츠를 유연하게 처리할 수 있는 기반을 마련했습니다.
- **중복 요청 방지**: 진행 중인 이미지/프롬프트 요청을 추적하는 `pendingFetchRef`를 추가하여, 데이터가 로드되는 동안 중복 호출이 발생하는 문제를 해결했습니다.